### PR TITLE
Fix README typo and lambda query params, add basic tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # sqlconverter
 SQL conversion between different dialects.
-This converter was first created for SQL conversion between Trino SQL to Starrrock SQL.
+This converter was first created for SQL conversion between Trino SQL to StarRocks SQL.
+Run tests with `pytest`.

--- a/app.py
+++ b/app.py
@@ -2,10 +2,11 @@
 # A Flask application for AWS Lambda to transpile Trino SQL to StarRocks SQL.
 #
 # To deploy this to AWS Lambda:
-# 1. You will need 'Flask', 'aws-wsgi', and 'sqlglot'.
+# 1. You will need 'Flask', 'aws-wsgi', 'sqlglot', and 'mangum'.
 #    Create a requirements.txt file with:
 #    Flask
 #    aws-wsgi
+#    mangum
 #    sqlglot
 #
 # 2. When configuring your Lambda function in AWS, set the handler to:
@@ -20,7 +21,7 @@
 
 from flask import Flask, request, jsonify
 import awsgi
-from urllib.parse import urlencode
+from urllib.parse import parse_qs
 import logging
 import json
 import sqlglot
@@ -177,10 +178,17 @@ def lambda_handler(event, context):
         if path == '/{proxy+}':
             path = '/'
         
+        query_params = event.get('queryStringParameters')
+        if query_params is None:
+            # Parse rawQueryString when API Gateway does not populate
+            # queryStringParameters. parse_qs returns lists, so flatten them.
+            parsed = parse_qs(event.get('rawQueryString', ''))
+            query_params = {k: v[0] if len(v) == 1 else v for k, v in parsed.items()}
+
         transformed_event = {
             'httpMethod': event['requestContext']['http']['method'],
-            'path': path, 
-            'queryStringParameters': event.get('queryStringParameters'),
+            'path': path,
+            'queryStringParameters': query_params,
             'headers': event.get('headers'),
             'body': event.get('body'),
             'isBase64Encoded': event.get('isBase64Encoded', False),

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app
+
+
+def test_transpile_success():
+    with app.test_client() as client:
+        response = client.post('/transpile', json={'sql_query': 'SELECT 1'})
+        assert response.status_code == 200
+        data = response.get_json()
+        assert 'transpiled_sql' in data
+
+
+def test_transpile_missing_sql_query():
+    with app.test_client() as client:
+        response = client.post('/transpile', json={})
+        assert response.status_code == 400
+        data = response.get_json()
+        assert 'error' in data
+


### PR DESCRIPTION
## Summary
- fix spelling of StarRocks in README
- mention how to run tests
- document `mangum` dependency in app.py comments
- parse query params for API Gateway v2 events in `lambda_handler`
- add simple tests for the `/transpile` endpoint

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_685b7baa11d08328ab900c3f0050777a